### PR TITLE
use configmap to set job template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-OPERATOR_IMG ?= ghcr.io/cloudtty/cloudshell-opeartor:latest
+OPERATOR_IMG ?= ghcr.io/cloudtty/cloudshell-operator:latest
 TTY_IMG ?= ghcr.io/cloudtty/cloudshell:latest
 #NOTE: job.yaml.tmpl image should align with above
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cloudshell-sample2   root   bash     NodePort    192.168.4.1:30385   Ready   9s
 
 When the status of cloudshell changes to `Ready` and the `URL` field appears, it can be accessed by the field in the browser, as shown below
 
-![screenshot_png](https://github.com/cloudtty/cloudtty/raw/main/pkg/docs/snapshot.png)
+![screenshot_png](https://github.com/cloudtty/cloudtty/raw/main/docs/snapshot.png)
 
 # Exposure Mode
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-# 这是一个 cloudshell 的 opeartor
+# 这是一个 cloudshell 的 operator
 
 简体中文 | [英文](https://github.com/cloudtty/cloudtty/blob/main/README.md)
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: cloudshell
+name: cloudtty
 description: A Helm chart for cloudshell
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -6,20 +6,35 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "cloudshell.controllerManager.fullname" -}}
+{{- define "cloudtty.controllerManager.fullname" -}}
 {{- printf "%s-%s-%s" (include "common.names.fullname" .) "controller" "manager" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "jobTemplate.config.fullname" -}}
+{{- printf "%s-%s-%s" (include "common.names.fullname" .) "job" "template" | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*
 Return the proper image name
 */}}
-{{- define "cloudshell.controllerManager.image" -}}
+{{- define "cloudtty.controllerManager.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the proper image Registry Secret Names
 */}}
-{{- define "cloudshell.controllerManager.imagePullSecrets" -}}
+{{- define "cloudtty.controllerManager.imagePullSecrets" -}}
 {{ include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{- end -}}
+
+{{- define "cloudtty.job.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.jobTemplate.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image Registry Secret Names
+*/}}
+{{- define "cloudtty.job.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.jobTemplate.image) "global" .Values.global) }}
 {{- end -}}

--- a/charts/templates/cloudshell-manager-config-configmap.yaml
+++ b/charts/templates/cloudshell-manager-config-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}-config
+  name: {{ include "cloudtty.controllerManager.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
 data:
   controller_manager_config.yaml: |

--- a/charts/templates/cloudshell-manager-serviceaccount.yaml
+++ b/charts/templates/cloudshell-manager-serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/templates/cloushell-manager-deployment.yaml
+++ b/charts/templates/cloushell-manager-deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    control-plane: {{ include "cloudshell.controllerManager.fullname" . }}
+    control-plane: {{ include "cloudtty.controllerManager.fullname" . }}
     {{- if .Values.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.labels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      control-plane: {{ include "cloudshell.controllerManager.fullname" . }}
+      control-plane: {{ include "cloudtty.controllerManager.fullname" . }}
       {{- if .Values.podLabels }}
       {{- include "common.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 4 }}
       {{- end }}
@@ -23,15 +23,16 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels:
-        control-plane: {{ include "cloudshell.controllerManager.fullname" . }}
+        control-plane: {{ include "cloudtty.controllerManager.fullname" . }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.podLabels "context" $ ) | nindent 4 }}
         {{- end }}
     spec:
-      {{- include "cloudshell.controllerManager.imagePullSecrets" . | nindent 6 }}
+      {{- include "cloudtty.controllerManager.imagePullSecrets" . | nindent 6 }}
       containers:
-        - name: {{ include "cloudshell.controllerManager.fullname" . }}
-          image: {{ include "cloudshell.controllerManager.image" . }}
+        - name: {{ include "cloudtty.controllerManager.fullname" . }}
+          image: {{ include "cloudtty.controllerManager.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - /manager
           - --leader-elect
@@ -50,6 +51,13 @@ spec:
               path: /readyz
               port: 8081
           {{- end }}
+          volumeMounts:
+          - mountPath: /etc/cloudtty
+            name: cloudtty-job-template
+      volumes:
+        - name: cloudtty-job-template
+          configMap:
+            name: {{ include "jobTemplate.config.fullname" . }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
@@ -59,5 +67,5 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "cloudshell.controllerManager.fullname" . }}
+      serviceAccountName: {{ include "cloudtty.controllerManager.fullname" . }}
       terminationGracePeriodSeconds: 10

--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
 rules:
 - apiGroups:
   - ""
@@ -37,3 +37,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["*"]
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs: ["*"]

--- a/charts/templates/clusterrolebinding.yaml
+++ b/charts/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/templates/job-template-configmap.yaml
+++ b/charts/templates/job-template-configmap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jobTemplate.config.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+data: 
+  job-temp.yaml: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      namespace: {{`{{ .Namespace }}`}}
+      name: {{`{{ .Name }}`}}
+      labels:
+        ownership: {{`{{ .Ownership }}`}}
+        {{- if .Values.labels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.jobTemplate.labels "context" $ ) | nindent 4 }}
+        {{- end }}
+    spec:
+      activeDeadlineSeconds: 3600
+      ttlSecondsAfterFinished: 60
+      parallelism: 1
+      completions: 1
+      template:
+        spec:
+          {{- include "cloudtty.job.imagePullSecrets" . | nindent 10 }}
+          containers:
+          - name: web-tty
+            image: {{ include "cloudtty.job.image" . }}
+            imagePullPolicy: {{ .Values.jobTemplate.image.pullPolicy }}
+            ports:
+            - containerPort: 7681
+              name: tty-ui
+              protocol: TCP
+            command:
+              - bash
+              - "-c"
+              - |
+                once=""
+                index=""
+                if [ "${ONCE}" == "true" ];then once=" --once "; fi;
+                if [ -f /index.html ]; then index=" --index /index.html ";fi
+                if [ -z "${TTL}" ] || [ "${TTL}" == "0" ];then
+                    ttyd ${index} ${once} sh -c "${COMMAND}"
+                else
+                    timeout ${TTL} ttyd ${index} ${once} sh -c "${COMMAND}" || echo "exiting"
+                fi
+            env:
+            - name: KUBECONFIG
+              value: /usr/local/kubeconfig/config
+            - name: ONCE
+              value: {{`"{{ .Once }}"`}}
+            - name: TTL
+              value: {{`"{{ .Ttl }}"`}}
+            - name: COMMAND
+              value: {{`{{ .Command }}`}}
+            volumeMounts:
+              - mountPath: /usr/local/kubeconfig/
+                name: kubeconfig
+          restartPolicy: Never
+          volumes:
+          - configMap:
+              defaultMode: 420
+              name: {{`{{ .Configmap }}`}}
+            name: kubeconfig

--- a/charts/templates/leaderelection-role.yaml
+++ b/charts/templates/leaderelection-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}-leader-election
+  name: {{ include "cloudtty.controllerManager.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:

--- a/charts/templates/leaderelection-rolebinding.yaml
+++ b/charts/templates/leaderelection-rolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "cloudshell.controllerManager.fullname" . }}-leader-election
+  name: {{ include "cloudtty.controllerManager.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "cloudshell.controllerManager.fullname" . }}-leader-election
+  name: {{ include "cloudtty.controllerManager.fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cloudshell.controllerManager.fullname" . }}
+  name: {{ include "cloudtty.controllerManager.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,7 +2,7 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-## @param global cloudshell global config
+## @param global cloudtty global config
 global:
   ## @param global.imageRegistry Global Docker image registry
   imageRegistry: ""
@@ -23,15 +23,15 @@ replicaCount: 1
 podAnnotations: {}
 ## @param controllerManager.podLabels
 podLabels: {}
-## @param image.registry cloudshell image registry
-## @param image.repository cloudshell image repository
-## @param image.tag cloudshell image tag (immutable tags are recommended)
-## @param image.pullPolicy cloudshell image pull policy
+## @param image.registry cloudtty image registry
+## @param image.repository cloudtty image repository
+## @param image.tag cloudtty image tag (immutable tags are recommended)
+## @param image.pullPolicy cloudtty image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
 image:
   registry: ghcr.io
-  repository: cloudtty/cloudshell-opeartor
+  repository: cloudtty/cloudshell-operator
   tag: "latest"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -83,3 +83,30 @@ readinessProbe:
   enabled: true
   initialDelaySeconds: 5
   periodSeconds: 10
+
+## @jobTemplate job template config
+jobTemplate:
+  ## @param jobTemplate.labels
+  labels: {}
+  ## @param image.registry cloudtty job image registry
+  ## @param image.repository cloudtty job image repository
+  ## @param image.tag cloudtty job image tag (immutable tags are recommended)
+  ## @param image.pullPolicy cloudtty job image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: ghcr.io
+    repository: cloudtty/cloudshell:latest
+    tag: "latest"
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []

--- a/config/manager/Job_template.yaml
+++ b/config/manager/Job_template.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudtty-job-template
+  namespace: system
+data: 
+  job-temp.yaml: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      namespace: {{ .Namespace }}
+      name: {{ .Name }}
+      labels:
+        ownership: {{ .Ownership }}
+    spec:
+      activeDeadlineSeconds: 3600
+      ttlSecondsAfterFinished: 60
+      parallelism: 1
+      completions: 1
+      template:
+        spec:
+          containers:
+          - name:  web-tty
+            image: ghcr.io/cloudtty/cloudshell:latest
+            imagePullPolicy: IfNotPresent
+            ports:
+            - containerPort: 7681
+              name: tty-ui
+              protocol: TCP
+            command:
+              - bash
+              - "-c"
+              - |
+                once=""
+                index=""
+                if [ "${ONCE}" == "true" ];then once=" --once "; fi;
+                if [ -f /index.html ]; then index=" --index /index.html ";fi
+                if [ -z "${TTL}" ] || [ "${TTL}" == "0" ];then
+                    ttyd ${index} ${once} sh -c "${COMMAND}"
+                else
+                    timeout ${TTL} ttyd ${index} ${once} sh -c "${COMMAND}" || echo "exiting"
+                fi
+            env:
+            - name: KUBECONFIG
+              value: /usr/local/kubeconfig/config
+            - name: ONCE
+              value: "{{ .Once }}"
+            - name: TTL
+              value: "{{ .Ttl }}"
+            - name: COMMAND
+              value: {{ .Command }}
+            volumeMounts:
+              - mountPath: /usr/local/kubeconfig/
+                name: kubeconfig
+          restartPolicy: Never
+          volumes:
+          - configMap:
+              defaultMode: 420
+              name: {{ .Configmap }}
+            name: kubeconfig

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,5 +56,12 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        volumeMounts:
+            - mountPath: /etc/cloudtty
+              name: cloudtty-job-template
+      volumes:
+        - name: cloudtty-job-template
+          configMap:
+            name: cloudtty-job-template
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/cloudshell_controller.go
+++ b/controllers/cloudshell_controller.go
@@ -195,7 +195,13 @@ func (c *CloudShellReconciler) ensureFinalizer(cluster *cloudshellv1alpha1.Cloud
 func (r *CloudShellReconciler) CreateCloudShellJob(ctx context.Context, cloudshell *cloudshellv1alpha1.CloudShell) error {
 	log := log.FromContext(ctx)
 
-	jobBytes, err := util.ParseTemplate(manifests.JobTmplV1, struct {
+	jobTmpl := manifests.JobTmplV1
+	if template, err := util.LoadYamlTemplate("/etc/cloudtty/job-temp.yaml"); err == nil {
+		log.Info("load cloudtty job template from /etc/cloudtty")
+		jobTmpl = template
+	}
+
+	jobBytes, err := util.ParseTemplate(jobTmpl, struct {
 		Namespace, Name, Ownership, Command, Configmap string
 		Once                                           bool
 		Ttl                                            int32


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind feature

the job template is hardcode in our code, the image and some value associated with the job cannot be set dynamically.

so, we need a configmap to set job template by value.yaml of chart.