### PR TITLE
check pod running status for cloudshell

### DIFF
--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -14,6 +14,12 @@ rules:
   - nodes
   verbs: ["get", "watch", "list"]
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -106,7 +106,7 @@ spec:
   - http:
       paths:
       - path: {{ .Path }}
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: {{ .ServiceName }}
@@ -130,7 +130,7 @@ spec:
   http:
   - match:
     - uri:
-        exact: {{ .Path }}
+        prefix: {{ .Path }}
     rewrite:
       uri: /
     route:


### PR DESCRIPTION
before set the `ready `phase to cloudshell, we should check the pod of job whether is running. as long as one of them is running, the coudshell is considered work.

/kind bug

fixed: https://github.com/cloudtty/cloudtty/issues/16

Signed-off-by: calvin <wen.chen@daocloud.io>