### PR TITLE
use serviceaccount generate kubeconfig

### DIFF
--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -11,19 +11,28 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs: ["create"]
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs: ["get", "watch", "list"]
 - apiGroups:
   - ""
   resources:
   - pods
-  verbs:
-  - list
+  verbs: ["list"]
 - apiGroups:
   - batch
   resources:
   - jobs
   verbs: ["*"]
+- apiGroups:
+  - rbac.authorization.k8s.io/v1
+  resources:
+  - rolebindings
+  verbs: ["create"]
 - apiGroups:
   - cloudshell.cloudtty.io
   resources:
@@ -33,16 +42,12 @@ rules:
   - cloudshell.cloudtty.io
   resources:
   - cloudshells/finalizers
-  verbs:
-  - update
+  verbs: ["update"]
 - apiGroups:
   - cloudshell.cloudtty.io
   resources:
   - cloudshells/status
-  verbs:
-  - get
-  - patch
-  - update
+  verbs: ["get", "patch", "update"]
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/templates/job-template-configmap.yaml
+++ b/charts/templates/job-template-configmap.yaml
@@ -45,20 +45,10 @@ data:
                     timeout ${TTL} ttyd ${index} ${once} sh -c "${COMMAND}" || echo "exiting"
                 fi
             env:
-            - name: KUBECONFIG
-              value: /usr/local/kubeconfig/config
             - name: ONCE
               value: {{`"{{ .Once }}"`}}
             - name: TTL
               value: {{`"{{ .Ttl }}"`}}
             - name: COMMAND
               value: {{`{{ .Command }}`}}
-            volumeMounts:
-              - mountPath: /usr/local/kubeconfig/
-                name: kubeconfig
           restartPolicy: Never
-          volumes:
-          - configMap:
-              defaultMode: 420
-              name: {{`{{ .Configmap }}`}}
-            name: kubeconfig

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name:  web-tty
-        image: ghcr.io/cloudtty/cloudshell:latest
+        image: ghcr.io/cloudtty/cloudshell:v0.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 7681
@@ -54,23 +54,13 @@ spec:
                 timeout ${TTL} ttyd ${index} ${once} sh -c "${COMMAND}" || echo "exiting"
             fi
         env:
-        - name: KUBECONFIG
-          value: /usr/local/kubeconfig/config
         - name: ONCE
           value: "{{ .Once }}"
         - name: TTL
           value: "{{ .Ttl }}"
         - name: COMMAND
           value: {{ .Command }}
-        volumeMounts:
-          - mountPath: /usr/local/kubeconfig/
-            name: kubeconfig
       restartPolicy: Never
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: {{ .Configmap }}
-        name: kubeconfig
 `
 
 	ServiceTmplV1 = `


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind feature

fixed: https://github.com/cloudtty/cloudtty/issues/14

KEP: https://github.com/cloudtty/cloudtty/blob/main/docs/keps/local-cluster-generate-kubeconfig.md

If we want open a current cluster terminal and create a configmap manually is complicated. we can use `serviceaaccount` in pod of controller  to generate kubeconfig and create confingmap for it. In the case, user specified a configmap to cloushell no more.

@panpan0000 cc