### PR TITLE
upgrade doc for new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ When the status of cloudshell changes to `Ready` and the `URL` field appears, it
 
 ![screenshot_png](https://github.com/cloudtty/cloudtty/raw/main/docs/snapshot.png)
 
+# Set kubeconfig
+
+* If the cluster is remote, `cloudtty` needs to specify `kubeconfig` to access the cluster using the kubectl command tool. you need to provide the kubeconfig stored in configmap and specify the name to cloudshell `spec.configmapName` cr. kubeconfig will be automatically mounted to the cloudtty container. ensure that the server IP address is properly connected to the cluster network.
+
+* If it is a local cluster, cloudtty will create a ServiceAccount with `cluster-admin` role permissions instead of providing kubeconfig. Inside the container, kubectl automatically detects 'CA'certificates and token. If there are a concerns with security, you can also provide your own kubeconfig to control the permissions of different users.
+
 # Exposure Mode
 
 Cloudtty provides four modes to expose cloudtty services: `ClusterIP`, `NodePort`, `Ingress`, and `VitualService` to satisfy different usage scenarios:

--- a/README_zh.md
+++ b/README_zh.md
@@ -61,6 +61,13 @@ cloudtty 提供了这些功能，请使用 cloudtty 吧🎉!
 
 ![screenshot_png](https://github.com/cloudtty/cloudtty/raw/main/docs/snapshot.png)
 
+
+# 设置 kubeconfig
+
+* 如果是远端集群，cloudtty 执行 kubectl 命令行工具访问集群需要指定 kubeconfig。需要用户自己提供 kubeconfig 储存在 comfigmap 中，并且在 `cloudshell` 的 cr 中 `spec.configmapName` 指定 configmap 的名称，cloudtty 会自动挂载到容器中。请确保 server 地址与集群网络连接是否顺畅。
+
+* 如果是本地集群，可以不提供 kubeconfig，cloudtty 会创建具有 `cluster-admin` 角色权限的 `serviceaccount`。在容器的内部，`kubectl` 会自动发现 `ca` 证书和 token。如果有安全上的考虑，同样也可以自己提供 kubeconfig 来控制不同用户的权限。
+
 # 访问方式
 
 Cloudtty 提供了4种模式来暴露后端的服务: `ClusterIP`, `NodePort`, `Ingress`, `VitualService`来满足不同的使用场景：

--- a/config/samples/ingress_v1alpha1_cloudshell.yaml
+++ b/config/samples/ingress_v1alpha1_cloudshell.yaml
@@ -9,7 +9,7 @@ spec:
  commandAction: "bash"
  exposureMode: "Ingress"
  pathPrefix: "/apis/cloudtty.io/"
- ttl: 100
+ ttl: 500
  once: false
  ingressConfig: 
     ingressName: "cloudshell-ingress-demo"

--- a/config/samples/local-cluster_v1alpha1_cloudshell.yaml
+++ b/config/samples/local-cluster_v1alpha1_cloudshell.yaml
@@ -1,10 +1,8 @@
 apiVersion: cloudshell.cloudtty.io/v1alpha1
 kind: CloudShell
 metadata:
-  name: cloudshell-sample
+  name: local-cluster-sample
 spec:
-  configmapName: "my-kubeconfig"
-  runAsUser: "root"
   commandAction: "bash"
   ttl: 500
   once: false

--- a/config/samples/vs_v1alpha1_cloudshell.yaml
+++ b/config/samples/vs_v1alpha1_cloudshell.yaml
@@ -9,7 +9,7 @@ spec:
  commandAction: "bash"
  exposureMode: "VirtualService"
  pathPrefix: "/apis/cloudtty.io/"
- ttl: 100
+ ttl: 500
  once: false
  virtualServiceConfig:
     virtualServiceName: "cloudshell-vs-demo"


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind documentation

update doc and sample:
* add section `set kubeconfig` for readme
* add `local-cluster-cloudshell` to sample
