### PR TITLE
fix chart rbac file

### DIFF
--- a/charts/cloudtty/templates/clusterrole.yaml
+++ b/charts/cloudtty/templates/clusterrole.yaml
@@ -31,7 +31,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io/v1
   resources:
-  - rolebindings
+  - clusterrolebindings
   verbs: ["create"]
 - apiGroups:
   - cloudshell.cloudtty.io


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind bug

fix chart rbac yaml. `rolebindings` => `clusterrolebindings`