### PR TITLE
fix make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths=./pkg/apis/... output:crd:artifacts:config=./config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths=./... output:crd:artifacts:config=./config/crd/bases
 	$(CONTROLLER_GEN) crd paths=./pkg/apis/... output:crd:dir=./charts/cloudtty/_crds
 
 .PHONY: generate


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

Fixed the controller-gen path to generate rbac yaml according to annotation of controller. e.g:

```
controllers/cloudshell_controller.go
+//+kubebuilder:rbac:groups="",resources=clusterrole,verbs=get;list;watch;create;update;patch;
+//+kubebuilder:rbac:groups="",resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;
```
/kind bug
