### PR TITLE
The operator should have full privilege, so that it can create admin clusterrolebinding for SA of cloudshell instance

### DIFF
--- a/charts/cloudtty/templates/clusterrole-limited-for-mgmt-remote-cluster.yaml
+++ b/charts/cloudtty/templates/clusterrole-limited-for-mgmt-remote-cluster.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cloudtty.controllerManager.fullname" . }}-limited
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs: ["create"]
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs: ["list"]
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs: ["*"]
+- apiGroups:
+  - rbac.authorization.k8s.io/v1
+  resources:
+  - clusterrolebindings
+  verbs: ["create"]
+- apiGroups:
+  - cloudshell.cloudtty.io
+  resources:
+  - cloudshells
+  verbs: ["*"]
+- apiGroups:
+  - cloudshell.cloudtty.io
+  resources:
+  - cloudshells/finalizers
+  verbs: ["update"]
+- apiGroups:
+  - cloudshell.cloudtty.io
+  resources:
+  - cloudshells/status
+  verbs: ["get", "patch", "update"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["*"]
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs: ["*"]

--- a/charts/cloudtty/templates/clusterrole.yaml
+++ b/charts/cloudtty/templates/clusterrole.yaml
@@ -4,57 +4,7 @@ metadata:
   name: {{ include "cloudtty.controllerManager.fullname" . }}
 rules:
 - apiGroups:
-  - ""
+  - '*'
   resources:
-  - services
-  verbs: ["*"]
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs: ["create"]
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs: ["get", "watch", "list"]
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs: ["list"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs: ["*"]
-- apiGroups:
-  - rbac.authorization.k8s.io/v1
-  resources:
-  - clusterrolebindings
-  verbs: ["create"]
-- apiGroups:
-  - cloudshell.cloudtty.io
-  resources:
-  - cloudshells
-  verbs: ["*"]
-- apiGroups:
-  - cloudshell.cloudtty.io
-  resources:
-  - cloudshells/finalizers
-  verbs: ["update"]
-- apiGroups:
-  - cloudshell.cloudtty.io
-  resources:
-  - cloudshells/status
-  verbs: ["get", "patch", "update"]
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs: ["*"]
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - virtualservices
+  - '*'
   verbs: ["*"]


### PR DESCRIPTION
when operator has limited privilege , it is not able to create `clusterrolebinding` for ServiceAccount for new cloudshell instance.
but when operator only managers remote cluster, then it doesn't need this privilege.

and backup original yaml to `clusterrole-limited-for-mgmt-remote-cluster.yaml` in case of remote cluster only senario  

Because managing local cluster is the most use case, so by default , apply the admin privilege clusterrolebinding for operator itslef .