### PR TITLE
add readliness and liveliness probe for cloudshell container

### DIFF
--- a/charts/cloudtty/templates/job-template-configmap.yaml
+++ b/charts/cloudtty/templates/job-template-configmap.yaml
@@ -56,6 +56,14 @@ data:
             volumeMounts:
               - mountPath: /usr/local/kubeconfig/
                 name: kubeconfig
+            readinessProbe:
+              tcpSocket:
+                port: 7681
+              periodSeconds: 5
+            livenessProbe:
+              tcpSocket:
+                port: 7681
+              periodSeconds: 20
           restartPolicy: Never
           volumes:
           - configMap:

--- a/config/manager/Job_template.yaml
+++ b/config/manager/Job_template.yaml
@@ -52,6 +52,14 @@ data:
             volumeMounts:
               - mountPath: /usr/local/kubeconfig/
                 name: kubeconfig
+            readinessProbe:
+              tcpSocket:
+                port: 7681
+              periodSeconds: 5
+            livenessProbe:
+              tcpSocket:
+                port: 7681
+              periodSeconds: 20
           restartPolicy: Never
           volumes:
           - configMap:

--- a/controllers/cloudshell_controller.go
+++ b/controllers/cloudshell_controller.go
@@ -696,8 +696,13 @@ func (c *CloudShellReconciler) isRunning(ctx context.Context, job *batchv1.Job) 
 			return false, err
 		}
 		for _, p := range pods.Items {
-			if p.Status.Phase == corev1.PodRunning {
-				return true, nil
+			if p.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			for _, c := range p.Status.Conditions {
+				if c.Type == corev1.ContainersReady && c.Status == corev1.ConditionTrue {
+					return true, nil
+				}
 			}
 		}
 		return false, nil

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -65,6 +65,14 @@ const (
           volumeMounts:
             - mountPath: /usr/local/kubeconfig/
               name: kubeconfig
+          readinessProbe:
+            tcpSocket:
+              port: 7681
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 7681
+            periodSeconds: 20
         restartPolicy: Never
         volumes:
         - configMap:


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind feature

* add readliness and liveliness probe for cloudshell container
* check pod condition `Ready` is `True`