### PR TITLE
reduce the time to ready for cloudshell

### DIFF
--- a/charts/cloudtty/templates/job-template-configmap.yaml
+++ b/charts/cloudtty/templates/job-template-configmap.yaml
@@ -59,7 +59,8 @@ data:
             readinessProbe:
               tcpSocket:
                 port: 7681
-              periodSeconds: 5
+              periodSeconds: 1
+              failureThreshold: 15
             livenessProbe:
               tcpSocket:
                 port: 7681

--- a/config/manager/Job_template.yaml
+++ b/config/manager/Job_template.yaml
@@ -55,7 +55,8 @@ data:
             readinessProbe:
               tcpSocket:
                 port: 7681
-              periodSeconds: 5
+              periodSeconds: 1
+              failureThreshold: 15
             livenessProbe:
               tcpSocket:
                 port: 7681

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -68,7 +68,8 @@ const (
           readinessProbe:
             tcpSocket:
               port: 7681
-            periodSeconds: 5
+            periodSeconds: 1
+            failureThreshold: 15
           livenessProbe:
             tcpSocket:
               port: 7681


### PR DESCRIPTION
1.  change the worker thread of the controller to 5
2. change the interval of cal pod status to 500 milliseconds
3. change the readinessProbe to 1s