### PR TITLE
Disable mount hosted cluster's service account

### DIFF
--- a/charts/cloudtty/templates/job-template-configmap.yaml
+++ b/charts/cloudtty/templates/job-template-configmap.yaml
@@ -22,6 +22,7 @@ data:
       completions: 1
       template:
         spec:
+          automountServiceAccountToken: false
           {{- include "cloudtty.job.imagePullSecrets" . | nindent 10 }}
           containers:
           - name: web-tty

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -32,6 +32,7 @@ const (
     completions: 1
     template:
       spec:
+        automountServiceAccountToken: false
         containers:
         - name:  web-tty
           image: ghcr.io/cloudtty/cloudshell:v0.2.0


### PR DESCRIPTION
This will bring several benefits.
1. the authentication information of the host cluster will not be sensed inside CloudShell Pod (in some cases, some permissions may be configured for the default SA).
2. The Namespace where the current instance is located is not sensed in CloudShell.