### PR TITLE
add chart lint workflow

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -1,0 +1,71 @@
+# validate any chart changes under charts directory
+name: Chart Lint
+
+env:
+  HELM_VERSION: v3.8.1
+  KIND_VERSION: v0.14.0
+  KIND_NODE_IMAGE: kindest/node:v1.23.4
+  K8S_VERSION: v1.23.4
+  DEFAULT_BRANCH: main
+
+on:
+  push:
+  pull_request:
+    paths:
+      - "charts/cloudtty/**"
+
+jobs:
+  chart-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v2.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.6.0
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          # https://github.com/helm/chart-testing-action/issues/25
+          # if the default branch is not master , the CLI exits with error
+          changed=$( ct list-changed --target-branch ${{ env.DEFAULT_BRANCH }}  )
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --target-branch=${{ env.DEFAULT_BRANCH }} --check-version-increment=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+        with:
+          wait: 120s
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_NODE_IMAGE }}
+          kubectl_version: ${{ env.K8S_VERSION }}
+
+      - name: Run chart-testing (install)
+        run: ct install --debug --target-branch ${{ env.DEFAULT_BRANCH }} --helm-extra-args "--timeout 400s"

--- a/charts/cloudtty/Chart.yaml
+++ b/charts/cloudtty/Chart.yaml
@@ -22,3 +22,10 @@ version: 0.3.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.3.0"
+
+sources:
+  - "https://github.com/clusterpedia-io/clusterpedia"
+
+maintainers:
+  - name: clusterpedia-io
+    url: https://github.com/clusterpedia-io/clusterpedia


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

/kind feature

we need a ci workflow to lint chart pkg. the workflow inclode:
`ct changed`: check whether file has changed in chart dir.
`ct lint`: verify that YAML files conform to the specification.
`ct install`: intall a clusterpedia release on kind cluster.