### PR TITLE
add featuregate to support storing kubeconfig in secret

### DIFF
--- a/charts/cloudtty/_crds/cloudshell.cloudtty.io_cloudshells.yaml
+++ b/charts/cloudtty/_crds/cloudshell.cloudtty.io_cloudshells.yaml
@@ -66,8 +66,10 @@ spec:
               commandAction:
                 type: string
               configmapName:
-                description: Configmap of the target kube-config, will replace by
-                  SA
+                description: 'Configmap of the target kube-config, will replace by
+                  SA TODO: it will be deprecated in v0.5.0 version and be removed
+                  in v0.6.0 if open the featuregate AllowSecretStoreKubeconfig, it''s
+                  not work.'
                 type: string
               exposureMode:
                 description: ExposeMode describes how to access ttyd service, either
@@ -113,7 +115,19 @@ spec:
                 type: string
               runAsUser:
                 type: string
+              secretRef:
+                description: 'SecretRef represents the secret contains mandatory credentials
+                  to access the target cluster. The secret should hold credentials
+                  as follows: - secret.data.token - secret.data.caBundle The field
+                  is alpha phase, paleas open the featuregate AllowSecretStoreKubeconfig
+                  to use it.'
+                properties:
+                  name:
+                    description: Name is the name of resource being referenced.
+                    type: string
+                type: object
               ttl:
+                description: 'TODO: repalce type `int32` of ttl with `time`.'
                 format: int32
                 type: integer
               urlArg:

--- a/charts/cloudtty/templates/job-template-configmap.yaml
+++ b/charts/cloudtty/templates/job-template-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "jobTemplate.config.fullname" . }}
   namespace: {{ .Release.Namespace }}
-data: 
+data:
   job-temp.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -68,7 +68,7 @@ data:
               periodSeconds: 20
           restartPolicy: Never
           volumes:
-          - configMap:
+          - secret:
               defaultMode: 420
-              name: {{`{{ .Configmap }}`}}
+              secretName: {{ .Secret }}
             name: kubeconfig

--- a/config/samples/cloudshell_v1alpha1_simple.yaml
+++ b/config/samples/cloudshell_v1alpha1_simple.yaml
@@ -1,0 +1,7 @@
+apiVersion: cloudshell.cloudtty.io/v1alpha1
+kind: CloudShell
+metadata:
+  name: cloudshell-simple
+spec:
+  secretRef:
+    name: "my-kubeconfig"

--- a/pkg/apis/cloudshell/v1alpha1/types.go
+++ b/pkg/apis/cloudshell/v1alpha1/types.go
@@ -46,8 +46,18 @@ type CloudShellSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Configmap of the target kube-config, will replace by SA
+	// TODO: it will be deprecated in v0.5.0 version and be removed in v0.6.0
+	// if open the featuregate AllowSecretStoreKubeconfig, it's not work.
 	// +required
 	ConfigmapName string `json:"configmapName,omitempty"`
+
+	// SecretRef represents the secret contains mandatory credentials to access the target cluster.
+	// The secret should hold credentials as follows:
+	// - secret.data.token
+	// - secret.data.caBundle
+	// The field is alpha phase, paleas open the featuregate AllowSecretStoreKubeconfig to use it.
+	// +optional
+	SecretRef *LocalSecretReference `json:"secretRef,omitempty"`
 
 	// +optional
 	RunAsUser string `json:"runAsUser,omitempty"`
@@ -128,6 +138,13 @@ type IngressConfig struct {
 	// IngressClassName specifies a ingress controller to ingress,
 	// it must be fill when the cluster have multiple ingress controller service.
 	IngressClassName string `json:"ingressClassName,omitempty"`
+}
+
+// LocalSecretReference is a reference to a secret within the enclosing
+// namespace.
+type LocalSecretReference struct {
+	// Name is the name of resource being referenced.
+	Name string `json:"name,omitempty"`
 }
 
 // CloudShellStatus defines the observed state of CloudShell

--- a/pkg/controllers/featuregate.go
+++ b/pkg/controllers/featuregate.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+
+	"github.com/cloudtty/cloudtty/pkg/utils/feature"
+)
+
+const (
+	// AllowSecretStoreKubeconfig is a feature gate for the cloudshell to store kubeconfig in secret.
+	//
+	// owner: @calvin0327
+	// alpha: v0.3.0
+	// beta: v0.4.0
+	AllowSecretStoreKubeconfig featuregate.Feature = "AllowSecretStoreKubeconfig"
+)
+
+func init() {
+	runtime.Must(feature.MutableFeatureGate.Add(defaultFeatureGates))
+}
+
+// defaultFeatureGates consists of all known cloudtty-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	AllowSecretStoreKubeconfig: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -75,9 +75,9 @@ const (
             periodSeconds: 20
         restartPolicy: Never
         volumes:
-        - configMap:
+        - secret:
             defaultMode: 420
-            name: {{ .Configmap }}
+            secretName: {{ .Secret }}
           name: kubeconfig
 `
 

--- a/pkg/utils/feature/gate.go
+++ b/pkg/utils/feature/gate.go
@@ -1,0 +1,15 @@
+package feature
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+	// MutableFeatureGate is a mutable version of FeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	MutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// FeatureGate is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use MutableFeatureGate.
+	FeatureGate featuregate.FeatureGate = MutableFeatureGate
+)

--- a/vendor/k8s.io/component-base/cli/globalflag/globalflags.go
+++ b/vendor/k8s.io/component-base/cli/globalflag/globalflags.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalflag
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"k8s.io/component-base/logs"
+)
+
+// AddGlobalFlags explicitly registers flags that libraries (klog, verflag, etc.) register
+// against the global flagsets from "flag" and "k8s.io/klog/v2".
+// We do this in order to prevent unwanted flags from leaking into the component's flagset.
+//
+// k8s.io/component-base/logs.SkipLoggingConfigurationFlags must be used as
+// option when the program also uses a LoggingConfiguration struct for
+// configuring logging. Then only flags not covered by that get added.
+func AddGlobalFlags(fs *pflag.FlagSet, name string, opts ...logs.Option) {
+	logs.AddFlags(fs, opts...)
+
+	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
+}
+
+// Register adds a flag to local that targets the Value associated with the Flag named globalName in flag.CommandLine.
+func Register(local *pflag.FlagSet, globalName string) {
+	if f := flag.CommandLine.Lookup(globalName); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		normalizeFunc := local.GetNormalizeFunc()
+		pflagFlag.Name = string(normalizeFunc(local, pflagFlag.Name))
+		local.AddFlag(pflagFlag)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", globalName))
+	}
+}

--- a/vendor/k8s.io/component-base/config/options/leaderelectionconfig.go
+++ b/vendor/k8s.io/component-base/config/options/leaderelectionconfig.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/component-base/config"
+)
+
+// BindLeaderElectionFlags binds the LeaderElectionConfiguration struct fields to a flagset
+func BindLeaderElectionFlags(l *config.LeaderElectionConfiguration, fs *pflag.FlagSet) {
+	fs.BoolVar(&l.LeaderElect, "leader-elect", l.LeaderElect, ""+
+		"Start a leader election client and gain leadership before "+
+		"executing the main loop. Enable this when running replicated "+
+		"components for high availability.")
+	fs.DurationVar(&l.LeaseDuration.Duration, "leader-elect-lease-duration", l.LeaseDuration.Duration, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	fs.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	fs.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
+	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
+		"The type of resource object that is used for locking during "+
+		"leader election. Supported options are 'leases', 'endpointsleases' "+
+		"and 'configmapsleases'.")
+	fs.StringVar(&l.ResourceName, "leader-elect-resource-name", l.ResourceName, ""+
+		"The name of resource object that is used for locking during "+
+		"leader election.")
+	fs.StringVar(&l.ResourceNamespace, "leader-elect-resource-namespace", l.ResourceNamespace, ""+
+		"The namespace of resource object that is used for locking during "+
+		"leader election.")
+}

--- a/vendor/k8s.io/component-base/version/verflag/verflag.go
+++ b/vendor/k8s.io/component-base/version/verflag/verflag.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package verflag defines utility functions to handle command line flags
+// related to version of Kubernetes.
+package verflag
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+
+	"k8s.io/component-base/version"
+)
+
+type versionValue int
+
+const (
+	VersionFalse versionValue = 0
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// The type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+	// "--version" will be treated as "--version=true"
+	flag.Lookup(name).NoOptDefVal = "true"
+}
+
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+const versionFlagName = "version"
+
+var (
+	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	programName = "Kubernetes"
+)
+
+// AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
+// same value as the global flags.
+func AddFlags(fs *flag.FlagSet) {
+	fs.AddFlag(flag.Lookup(versionFlagName))
+}
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", version.Get())
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("%s %s\n", programName, version.Get())
+		os.Exit(0)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -955,7 +955,9 @@ k8s.io/code-generator/third_party/forked/golang/reflect
 ## explicit; go 1.19
 k8s.io/component-base/cli
 k8s.io/component-base/cli/flag
+k8s.io/component-base/cli/globalflag
 k8s.io/component-base/config
+k8s.io/component-base/config/options
 k8s.io/component-base/config/v1alpha1
 k8s.io/component-base/featuregate
 k8s.io/component-base/logs
@@ -971,6 +973,7 @@ k8s.io/component-base/term
 k8s.io/component-base/tracing
 k8s.io/component-base/tracing/api/v1
 k8s.io/component-base/version
+k8s.io/component-base/version/verflag
 # k8s.io/gengo v0.0.0-20211129171323-c02415ce4185
 ## explicit; go 1.13
 k8s.io/gengo/args


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

fixed: https://github.com/cloudtty/cloudtty/issues/90

We add a featuregate `AllowSecretStoreKubeconfig` to support using secret to store kubeconfig. 
As there are some user have using our project, so the featuregate is `alpha` pahse currently.  we plan to upgrade it to beta phase at `v0.5.0` version and disable configmap at the same time and remove configmap at `v0.6.0` version.