### PR TITLE
add node-shell plugin to kubectl

### DIFF
--- a/docker/cloudshell/Dockerfile
+++ b/docker/cloudshell/Dockerfile
@@ -11,6 +11,11 @@ RUN yarn run build
 FROM ghcr.io/dtzar/helm-kubectl:3.9
 SHELL [ "/bin/bash", "-c" ]
 
+ARG TTYD_VERSION=1.6.3
+ARG ETCDCTL_VERSION=v3.4.20
+ARG KREW_VERSION=v0.4.3
+ARG KARMACTL_VERSION=v1.2.0
+
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
     && apk -U upgrade \
     && apk add --no-cache ca-certificates lrzsz \
@@ -23,24 +28,31 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repos
     && echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 
 RUN ttydArch="$(uname -m)" && echo "Building arch of $ttydArch.." \
-    && curl -LO https://github.com/tsl0922/ttyd/releases/download/1.6.3/ttyd.${ttydArch} \
+    && curl -LO https://github.com/tsl0922/ttyd/releases/download/$TTYD_VERSION/ttyd.${ttydArch} \
     && chmod +x ttyd.${ttydArch} \
     && mv ttyd.${ttydArch} /usr/local/bin/ttyd \
     && which ttyd \
     && mkdir kubeconf \
     && ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && echo "Building ARCH of $ARCH.." \
-    && curl -fsSLO https://github.com/karmada-io/karmada/releases/download/v1.2.0/kubectl-karmada-linux-${ARCH}.tgz \
+    && curl -fsSLO https://github.com/etcd-io/etcd/releases/download/$ETCDCTL_VERSION/etcd-$ETCDCTL_VERSION-linux-${ARCH}.tar.gz \
+    && tar -zxf etcd-$ETCDCTL_VERSION-linux-${ARCH}.tar.gz \
+    && chmod +x etcd-$ETCDCTL_VERSION-linux-${ARCH}/etcdctl \
+    && mv etcd-$ETCDCTL_VERSION-linux-${ARCH}/etcdctl /usr/local/bin/etcdctl \
+    && rm -rf etcd-$ETCDCTL_VERSION-linux-* \
+    && curl -fsSLO https://github.com/kubernetes-sigs/krew/releases/download/$KREW_VERSION/krew-linux_${ARCH}.tar.gz \
+    && tar -zxf krew-linux_${ARCH}.tar.gz \
+    && chmod +x krew-linux_${ARCH} \
+    && mv krew-linux_${ARCH} /usr/local/bin/kubectl-krew \
+    && kubectl krew version \
+    && echo 'PATH="${PATH}:${HOME}/.krew/bin"' >>~/.bashrc \
+    && rm -rf krew-linux_* \
+    && kubectl krew index add kvaps https://github.com/kvaps/krew-index \
+    && kubectl krew install kvaps/node-shell \
+    && curl -fsSLO https://github.com/karmada-io/karmada/releases/download/$KARMACTL_VERSION/kubectl-karmada-linux-${ARCH}.tgz \
     && tar -zxf kubectl-karmada-linux-${ARCH}.tgz \
     && chmod +x kubectl-karmada \
-    && mv kubectl-karmada /usr/local/bin/kubectl-karmada \
-    && which kubectl-karmada \
-    && rm -rf kubectl-karmada-linux-* \
-    && curl -fsSLO https://github.com/etcd-io/etcd/releases/download/v3.4.20/etcd-v3.4.20-linux-${ARCH}.tar.gz \
-    && tar -zxf etcd-v3.4.20-linux-${ARCH}.tar.gz \
-    && chmod +x etcd-v3.4.20-linux-${ARCH}/etcdctl \
-    && mv etcd-v3.4.20-linux-${ARCH}/etcdctl /usr/local/bin/etcdctl \
-    && which kubectl-karmada \
-    && rm -rf etcd-v3.4.20-linux-*
+    && mv kubectl-karmada ~/.krew/bin/kubectl-karmada \
+    && rm -rf kubectl-karmada-linux-*
 
 COPY --from=builder /app/dist/inline.html index.html
 ENTRYPOINT ttyd


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

fixed: https://github.com/cloudtty/cloudtty/issues/99

/kind feature

add node-shell plugin to kubectl.