### PR TITLE
bump cloudtty version to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ After the cloudtty is intergated to your own UI, it would look like:
   ```shell
   helm repo add cloudtty https://release.daocloud.io/chartrepo/cloudshell
   helm repo update
-  helm install cloudtty-operator --version 0.4.1 cloudtty/cloudtty
+  helm install cloudtty-operator --version 0.5.0 cloudtty/cloudtty
   ```
 
   b. Wait for the operator pod until it is running
@@ -59,7 +59,7 @@ After the cloudtty is intergated to your own UI, it would look like:
 - Step 2: Create a cloudtty instance by applying CR, and then monitor its status
 
   ```shell
-  kubectl apply -f https://raw.githubusercontent.com/cloudtty/cloudtty/v0.4.1/config/samples/local_cluster_v1alpha1_cloudshell.yaml
+  kubectl apply -f https://raw.githubusercontent.com/cloudtty/cloudtty/v0.5.0/config/samples/local_cluster_v1alpha1_cloudshell.yaml
   ```
 
   By default, it will create a cloudtty pod and expose the `NodePort` service.
@@ -90,7 +90,7 @@ Most users need more than just the basic `kubectl` tools to manage their cluster
 - Modify [Dockerfile.example](https://github.com/cloudtty/cloudtty/blob/main/docker/Dockerfile.example).
 
   ```shell
-  FROM ghcr.io/cloudtty/cloudshell:v0.4.1
+  FROM ghcr.io/cloudtty/cloudshell:v0.5.0
 
   RUN curl -fsSLO https://github.com/karmada-io/karmada/releases/download/v1.2.0/kubectl-karmada-linux-amd64.tgz \
       && tar -zxf kubectl-karmada-linux-amd64.tgz \
@@ -126,7 +126,7 @@ There are two ways to set the customized cloudshell image:
 2. Set the 'JobTemplate' image parameter to run the customized cloudshell image when installing cloudtty.
 
     ```shell
-    helm install cloudtty-operator --version 0.4.1 cloudtty/cloudtty --set jobTemplate.image.registry=</REGISTRY> --set jobTemplate.image.repository=</REPOSITORY> --set jobTemplate.image.tag=</TAG>
+    helm install cloudtty-operator --version 0.5.0 cloudtty/cloudtty --set jobTemplate.image.registry=</REGISTRY> --set jobTemplate.image.repository=</REPOSITORY> --set jobTemplate.image.tag=</TAG>
     ```
 
 > If you have installed cloudtty, you can also modify the configMap of JobTemplate to set the cloudshell image.

--- a/README_zh.md
+++ b/README_zh.md
@@ -49,14 +49,14 @@ cloudtty 的入门比较简单，请参照以下步骤进行安装和使用。
   ```
   helm repo add cloudtty https://release.daocloud.io/chartrepo/cloudshell
   helm repo update
-  helm install cloudtty-operator --version 0.4.1 cloudtty/cloudtty
+  helm install cloudtty-operator --version 0.5.0 cloudtty/cloudtty
   kubectl wait deployment cloudtty-operator-controller-manager --for=condition=Available=True
   ```
 
 2. 创建 CR，启动 cloudtty 的实例，并观察其状态。
 
   ```
-  kubectl apply -f https://raw.githubusercontent.com/cloudtty/cloudtty/v0.4.1/config/samples/local_cluster_v1alpha1_cloudshell.yaml
+  kubectl apply -f https://raw.githubusercontent.com/cloudtty/cloudtty/v0.5.0/config/samples/local_cluster_v1alpha1_cloudshell.yaml
   ```
 
   更多范例，参见`config/samples/`。
@@ -86,7 +86,7 @@ cloudtty 的入门比较简单，请参照以下步骤进行安装和使用。
 * 修改 ![Dockerfile.example](https://github.com/cloudtty/cloudtty/blob/main/docker/Dockerfile.example) 文件。
 
 ```shell
-FROM ghcr.io/cloudtty/cloudshell:v0.4.1
+FROM ghcr.io/cloudtty/cloudshell:v0.5.0
 
 RUN curl -fsSLO https://github.com/karmada-io/karmada/releases/download/v1.2.0/kubectl-karmada-linux-amd64.tgz \
     && tar -zxf kubectl-karmada-linux-amd64.tgz \
@@ -122,7 +122,7 @@ spec:
 2. 在安装 cloudtty 时可以设置 `JobTemplate` 镜像参数来运行自己的 cloudshell 的镜像。
 
 ```shell
-helm install cloudtty-operator --version 0.4.1 cloudtty/cloudtty --set jobTemplate.image.registry=</REGISTRY> --set jobTemplate.image.repository=</REPOSITORY> --set jobTemplate.image.tag=</TAG>
+helm install cloudtty-operator --version 0.5.0 cloudtty/cloudtty --set jobTemplate.image.registry=</REGISTRY> --set jobTemplate.image.repository=</REPOSITORY> --set jobTemplate.image.tag=</TAG>
 ```
 
 > 如果你已经安装了 cloudtty，还可以修改 `JobTemplate` 的 configmap 来设置 cloudshell 的镜像。

--- a/charts/cloudtty/Chart.yaml
+++ b/charts/cloudtty/Chart.yaml
@@ -15,17 +15,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.1"
+appVersion: "0.5.0"
 
 sources:
   - "https://github.com/cloudtty/cloudtty"
 
 maintainers:
-  - name: clusterpedia-io
+  - name: cloudtty
     url: https://github.com/cloudtty/cloudtty

--- a/charts/cloudtty/values.yaml
+++ b/charts/cloudtty/values.yaml
@@ -32,7 +32,7 @@ podLabels: {}
 image:
   registry: ghcr.io
   repository: cloudtty/cloudshell-operator
-  tag: "v0.4.1"
+  tag: "v0.5.0"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -81,8 +81,8 @@ readinessProbe:
 featureGates:
   # AllowSecretStoreKubeconfig is a feature gate for the cloudshell to store kubeconfig in secret.
   # owner: @calvin0327
-  # alpha: v0.3.0
-  # beta: v0.4.0
+  # alpha: v0.4.0
+  # beta: v0.5.0
   AllowSecretStoreKubeconfig: false
 
 ## @jobTemplate job template config
@@ -98,7 +98,7 @@ jobTemplate:
   image:
     registry: ghcr.io
     repository: cloudtty/cloudshell
-    tag: "v0.4.1"
+    tag: "v0.5.0"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/config/samples/cloudshell_v1alpha1_cloudshell.yaml
+++ b/config/samples/cloudshell_v1alpha1_cloudshell.yaml
@@ -8,4 +8,4 @@ spec:
   commandAction: "bash"
   ttl: 500
   once: false
-  image: ghcr.io/cloudtty/cloudshell:v0.4.1
+  image: ghcr.io/cloudtty/cloudshell:v0.5.0

--- a/docker/Dockerfile.example
+++ b/docker/Dockerfile.example
@@ -1,4 +1,4 @@
-FROM ghcr.io/cloudtty/cloudshell:v0.4.1
+FROM ghcr.io/cloudtty/cloudshell:v0.5.0
 
 RUN curl -fsSLO https://github.com/karmada-io/karmada/releases/download/v1.2.0/kubectl-karmada-linux-amd64.tgz \
     && tar -zxf kubectl-karmada-linux-amd64.tgz \

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -30,7 +30,7 @@ const (
         automountServiceAccountToken: false
         containers:
         - name: web-tty
-          image: "ghcr.io/cloudtty/cloudshell:v0.4.1"
+          image: "ghcr.io/cloudtty/cloudshell:v0.5.0"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 7681


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

bump cloudtty version to v0.5.0:
1. https://github.com/cloudtty/cloudtty/pull/164
2. https://github.com/cloudtty/cloudtty/pull/167
3. https://github.com/cloudtty/cloudtty/pull/168
4. https://github.com/cloudtty/cloudtty/pull/170
