### PR TITLE
bump cloudtty version to v0.5.1

### DIFF
--- a/charts/cloudtty/Chart.yaml
+++ b/charts/cloudtty/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 
 sources:
   - "https://github.com/cloudtty/cloudtty"

--- a/charts/cloudtty/values.yaml
+++ b/charts/cloudtty/values.yaml
@@ -32,7 +32,7 @@ podLabels: {}
 image:
   registry: ghcr.io
   repository: cloudtty/cloudshell-operator
-  tag: "v0.5.0"
+  tag: "v0.5.1"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -46,7 +46,8 @@ image:
   ##
   pullSecrets: []
 ## @param controllerManager.resources
-resources: {}
+resources:
+  {}
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
@@ -98,7 +99,7 @@ jobTemplate:
   image:
     registry: ghcr.io
     repository: cloudtty/cloudshell
-    tag: "v0.5.0"
+    tag: "v0.5.1"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -30,7 +30,7 @@ const (
         automountServiceAccountToken: false
         containers:
         - name: web-tty
-          image: "ghcr.io/cloudtty/cloudshell:v0.5.0"
+          image: "ghcr.io/cloudtty/cloudshell:v0.5.1"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 7681


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

bump cloudtty version to v0.5.1:

* support specified container to download & upload files
