### PR TITLE
fix build-push-action produces unknown arch

### DIFF
--- a/.github/workflows/build-image-release.yaml
+++ b/.github/workflows/build-image-release.yaml
@@ -50,7 +50,7 @@ jobs:
           driver-opts: image=moby/buildkit:master
 
       - name: Build & Pushing operator image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           context: .
           file: ${{ env.IMAGE_ROOT_PATH }}/operator/Dockerfile
@@ -62,10 +62,11 @@ jobs:
             VERSION=${{ steps.get_version.outputs.VERSION }}
           tags: ${{ env.REGISTER }}/${{ env.IMAGE_REPO }}/cloudshell-operator:${{ steps.get_version.outputs.VERSION }}
           push: true
+          provenance: false
           github-token: ${{ env.REGISTER_PASSWORD }}
 
       - name: Build & Pushing cloudshell image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           context: .
           file: ${{ env.IMAGE_ROOT_PATH }}/cloudshell/Dockerfile
@@ -77,4 +78,5 @@ jobs:
             VERSION=${{ steps.get_version.outputs.VERSION }}
           tags: ${{ env.REGISTER }}/${{ env.IMAGE_REPO }}/cloudshell:${{ steps.get_version.outputs.VERSION }}
           push: true
+          provenance: false
           github-token: ${{ env.REGISTER_PASSWORD }}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
![image](https://user-images.githubusercontent.com/10629406/231201421-5452a338-615d-4f8e-8511-266573cf9011.png)

The multi-architecture image produced by build-push-action will contain an image of the unknown architecture.
The solution is: https://github.com/docker/build-push-action/issues/820#issuecomment-1484092146

**Which issue(s) this PR fixes**:
https://github.com/docker/build-push-action/issues/820