### PR TITLE
Solve some CRITICAL problems in CVE

### DIFF
--- a/docker/cloudshell/Dockerfile
+++ b/docker/cloudshell/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8.0 as builder
+FROM node:18.16.0 as builder
 
 # Build frontend code which added upload/download button
 WORKDIR /app
@@ -9,13 +9,13 @@ RUN yarn install
 COPY html/ /app/
 RUN yarn run build
 
-FROM ghcr.io/dtzar/helm-kubectl:3.9
+FROM ghcr.io/dtzar/helm-kubectl:3.12.2
 SHELL [ "/bin/bash", "-c" ]
 
 ARG TTYD_VERSION=1.7.2
-ARG ETCDCTL_VERSION=v3.4.20
+ARG ETCDCTL_VERSION=v3.4.27
 ARG KREW_VERSION=v0.4.3
-ARG KARMACTL_VERSION=v1.5.0
+ARG KARMACTL_VERSION=v1.5.2
 
 RUN echo "https://mirrors.aliyun.com/alpine/edge/testing/" >> /etc/apk/repositories \
     && apk update \

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.3 as builder
+FROM golang:1.19.10 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
There are some CRITICAL problems in version 0.5.4
![图片](https://github.com/cloudtty/cloudtty/assets/66821741/c045ae84-628e-4767-8cde-0d5fb483b27f)
After the upgrade:
![图片](https://github.com/cloudtty/cloudtty/assets/66821741/378d68c1-edbc-440c-8c59-057327547f88)
However, there are still some MEDIUM issues that have not been solved, should be some openSSL issues, I want to upgrade node to 0.20.0 or higher, found not support!