### PR TITLE
Update base image to fix CVE-2022-48174

### DIFF
--- a/docker/cloudshell/Dockerfile
+++ b/docker/cloudshell/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn install
 COPY html/ /app/
 RUN yarn run build
 
-FROM ghcr.io/dtzar/helm-kubectl:3.12.2
+FROM ghcr.io/dtzar/helm-kubectl:3.12.3
 SHELL [ "/bin/bash", "-c" ]
 
 ARG TTYD_VERSION=1.7.2


### PR DESCRIPTION
```
 kebe@Kebe-PC  ~  docker run --rm -it ghcr.io/dtzar/helm-kubectl:3.12.3 bash
Unable to find image 'ghcr.io/dtzar/helm-kubectl:3.12.3' locally
3.12.3: Pulling from dtzar/helm-kubectl
7264a8db6415: Pull complete
408fc7707c2f: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:cc0ba524816c8482716eaa1d06b76d7de44dace8ace1b9173079077814f30623
Status: Downloaded newer image for ghcr.io/dtzar/helm-kubectl:3.12.3
f0397dd1f6d6:/config# cat --help
BusyBox v1.36.1 (2023-07-27 17:12:24 UTC) multi-call binary.
```

https://avd.aquasec.com/nvd/2022/cve-2022-48174/