### PR TITLE
Fix failed to render helm template

### DIFF
--- a/charts/cloudtty/templates/cloushell-manager-deployment.yaml
+++ b/charts/cloudtty/templates/cloushell-manager-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       {{- if .Values.podAnnotations }}
       annotations:
-      {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.podAnnotations "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels:
         control-plane: {{ include "cloudtty.controllerManager.fullname" . }}


### PR DESCRIPTION
before
``` shell
helm template cloudtty ./charts/cloudtty --set podAnnotations."kubernetes\.io/role"=master

% Error: template: cloudtty/templates/cloushell-manager-deployment.yaml:20:65: executing "cloudtty/templates/cloushell-manager-deployment.yaml" at <.Values.apiserver.podAnnotations>: nil pointer evaluating interface {}.podAnnotations

Use --debug flag to render out invalid YAML


```

now

``` shell

helm template cloudtty ./charts/cloudtty --set podAnnotations."kubernetes\.io/role"=master

# Source: cloudtty/templates/cloushell-manager-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cloudtty-controller-manager
  namespace: default
  labels:
    control-plane: cloudtty-controller-manager
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: cloudtty-controller-manager
  template:
    metadata:
      annotations:
        kubernetes.io/role: master
      labels:
        control-plane: cloudtty-controller-manager
    spec:
      
      containers:
        - name: cloudtty-controller-manager
          image: ghcr.io/cloudtty/cloudshell-operator:v0.5.7
          imagePullPolicy: IfNotPresent
          command:
          - manager
          - --leader-elect-resource-namespace=default
          - --v=2
          livenessProbe:


```
