### PR TITLE
update image source URL for proper display

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use it anywhere with an internet conneciton and it will be automatically
 > Early user terminals connected to computers were electromechanical teleprinters or teletypewriters (TeleTYpewriter, TTY), which might be the origin of TTY.
 > Gradually, TTY has continued to be used as the name for a text-only console although now this text-only console is a virtual console not a physical console.
 
-<img src="https://github.com/cncf/artwork/blob/master/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png" style="width:600px;" />
+<img src="https://github.com/cncf/artwork/blob/main/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png?raw=true" style="width:600px;" />
 
 **cloudtty is a [Cloud Native Computing Foundation](https://cncf.io/) landscape project.**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,7 +13,7 @@ CloudTTY 意指云原生虚拟控制台，也称为 Cloud Shell（云壳）。
 > 没错，就是那种很古老会发出滴滴答答声响、用线缆相连的有线电报机，那是一种只负责显示和打字的纯 IO 设备。
 > 近些年随着虚拟化技术的飞速发展，TTY 常指虚拟控制台或虚拟终端。
 
-<img src="https://github.com/cncf/artwork/blob/master/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png" style="width:600px;" />
+<img src="https://github.com/cncf/artwork/blob/main/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png?raw=true" style="width:600px;" />
 
 **CloudTTY 是一个[云原生计算基金会 (CNCF)](https://cncf.io/) 全景图项目。**
 


### PR DESCRIPTION
Changed the image source URL 
from:
https://github.com/cncf/artwork/blob/master/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png

to:
https://github.com/cncf/artwork/blob/main/other/illustrations/ashley-mcnamara/transparent/cncf-cloud-gophers-transparent.png?raw=true

This modification ensures the image is correctly displayed in the rendered content.