### PR TITLE
support setting service buffer size

### DIFF
--- a/charts/cloudtty/_crds/cloudshell.cloudtty.io_cloudshells.yaml
+++ b/charts/cloudtty/_crds/cloudshell.cloudtty.io_cloudshells.yaml
@@ -231,6 +231,10 @@ spec:
                     description: Name is the name of resource being referenced.
                     type: string
                 type: object
+              serverBufferSize:
+                description: ServerBufferSize specified service buffer size.
+                format: int64
+                type: integer
               ttlSecondsAfterStarted:
                 format: int64
                 type: integer

--- a/docker/cloudshell/Dockerfile
+++ b/docker/cloudshell/Dockerfile
@@ -12,7 +12,7 @@ RUN yarn run build
 FROM ghcr.io/dtzar/helm-kubectl:3.15.4
 SHELL [ "/bin/bash", "-c" ]
 
-ARG TTYD_VERSION=1.7.4
+ARG TTYD_VERSION=1.7.8
 
 RUN echo "https://mirrors.aliyun.com/alpine/v3.18/main/" >> /etc/apk/repositories \
     && apk update \
@@ -33,8 +33,9 @@ RUN echo "https://mirrors.aliyun.com/alpine/v3.18/main/" >> /etc/apk/repositorie
     && echo 'alias k=kubectl' >>~/.bashrc \
     && echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 
+# https://github.com/flpanbin/ttyd/releases/download/1.7.8/ttyd.i686
 RUN ttydArch="$(uname -m)" && echo "Building arch of $ttydArch.." \
-    && curl -LO https://github.com/tsl0922/ttyd/releases/download/$TTYD_VERSION/ttyd.${ttydArch} \
+    && curl -LO https://github.com/cloudtty/ttyd/releases/download/$TTYD_VERSION/ttyd.${ttydArch} \
     && chmod +x ttyd.${ttydArch} \
     && mv ttyd.${ttydArch} /usr/local/bin/ttyd \
     && which ttyd

--- a/docker/cloudshell/script/startup.sh
+++ b/docker/cloudshell/script/startup.sh
@@ -11,6 +11,7 @@ COMMAND=${4:-"bash"}
 POD_NAME=${5:-}
 POD_NAMESPACE=${6:-"default"}
 CONTAINER=${7:-}
+SERVER_BUFFER_SIZE=${8:-}
 
 if [ -d /root -a "`ls /root`" != "" ]; then         
   rm -rf /root/*                                    
@@ -36,15 +37,23 @@ source /root/.bashrc
 once=""
 index=""
 urlarg=""
+server_buffer_size=""
+
 if [[ "${ONCE}" == "true" ]];then
   once=" --once "
 fi
+
 if [[ -f /usr/lib/ttyd/index.html ]]; then
   index=" --index /usr/lib/ttyd/index.html "
 fi
+
 if [[ "${URLARG}" == "true" ]];then
   urlarg=" -a "
 fi
 
-nohup ttyd -W ${index} ${once} ${urlarg} sh -c "${COMMAND}" > /usr/lib/ttyd/nohup.log 2>&1 &
+if [[ -n "${SERVER_BUFFER_SIZE}" ]]; then
+  server_buffer_size=" --serv_buffer_size ${SERVER_BUFFER_SIZE} "
+fi
+
+nohup ttyd -W ${index} ${once} ${urlarg} ${server_buffer_size} sh -c "${COMMAND}" > /usr/lib/ttyd/nohup.log 2>&1 &
 echo "Start ttyd successully."

--- a/pkg/apis/cloudshell/v1alpha1/types.go
+++ b/pkg/apis/cloudshell/v1alpha1/types.go
@@ -105,6 +105,10 @@ type CloudShellSpec struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// ServerBufferSize specified service buffer size.
+	// +optional
+	ServerBufferSize *int64 `json:"serverBufferSize,omitempty"`
 }
 
 // VirtualServiceConfig specifies some of the parameters necessary to create the virtaulService.

--- a/pkg/apis/cloudshell/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cloudshell/v1alpha1/zz_generated.deepcopy.go
@@ -116,6 +116,11 @@ func (in *CloudShellSpec) DeepCopyInto(out *CloudShellSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ServerBufferSize != nil {
+		in, out := &in.ServerBufferSize, &out.ServerBufferSize
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllers/cloudshell_controller.go
+++ b/pkg/controllers/cloudshell_controller.go
@@ -373,6 +373,9 @@ func (c *Controller) StartupWorker(_ context.Context, cloudshell *cloudshellv1al
 		string(kubeConfigByte), fmt.Sprint(cloudshell.Spec.Once), fmt.Sprint(cloudshell.Spec.UrlArg),
 		cloudshell.Spec.CommandAction, podName, namespace, container,
 	}
+	if cloudshell.Spec.ServerBufferSize != nil {
+		ttydCommand = append(ttydCommand, fmt.Sprint(*cloudshell.Spec.ServerBufferSize))
+	}
 	return execCommand(cloudshell, ttydCommand, c.config)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Ttyd added a parameter [serv_buffer_size](https://github.com/cloudtty/ttyd/pull/1) to support setting server buffer size.

Add a new filed ServerBufferSize for cloudshell, to support setting the buffer size of ttyd service.

**Test Results**

Create  a cloudshell and set serverBufferSize = 131072

```shell

panbin@Pro cloudtty % cat cloudshell-virtualservice.yaml
apiVersion: cloudshell.cloudtty.io/v1alpha1
kind: CloudShell
metadata:
  finalizers:
  - cloudtty.io/cloudshell-controller
  name: test-buffer-size
  namespace: ns1
spec:
  cleanup: true
  commandAction: kubectl logs -f --tail 100 apiserver-5fb6f59d57-jrggf -n ns1
  exposureMode: VirtualService
  image: cloudtty/cloudshell:dev
  secretRef:
    name: cloudshell-apiserver-5fb6f59d57-jrggf-k-17303598302fqgh4
  ttlSecondsAfterStarted: 3600
  serverBufferSize: 131072
  virtualServiceConfig:
    export_to: istio-system
    gateway: istio-system/istio-gateway
    namespace: ns1
    virtualServiceName: cloudtty
```

check the ttyd logs: 
```shell

~ # cat /usr/lib/ttyd/nohup.log
[2024/10/31 07:31:48:1519] N: ttyd 1.7.8-b7db7e3 (libwebsockets 4.3.3-unknown)
[2024/10/31 07:31:48:1519] N: tty configuration:
[2024/10/31 07:31:48:1519] N:   start command: sh -c kubectl logs -f --tail 100 apiserver-5fb6f59d57-jrggf -n ns1 [2024/10/31 07:31:48:1519] N:   close signal: SIGHUP (1)
[2024/10/31 07:31:48:1520] N:   terminal type: xterm-256color
[2024/10/31 07:31:48:1520] N:   custom index.html: /usr/lib/ttyd/index.html
[2024/10/31 07:31:48:1520] N:   Service buffer size: 131072 bytes
[2024/10/31 07:31:48:1521] N: lws_create_context: LWS: 4.3.3-unknown, MbedTLS-2.28.5 NET SRV H1 H2 WS ConMon IPV6-off
[2024/10/31 07:31:48:1547] N: elops_init_pt_uv:  Using foreign event loop...
[2024/10/31 07:31:48:1548] N: __lws_lc_tag:  ++ [wsi|0|pipe] (1)
[2024/10/31 07:31:48:1549] N: __lws_lc_tag:  ++ [vh|0|netlink] (1)
[2024/10/31 07:31:48:1550] N: __lws_lc_tag:  ++ [vh|1|default||7681] (2)
[2024/10/31 07:31:48:1551] N: [vh|1|default||7681]: lws_socket_bind: source ads 0.0.0.0
[2024/10/31 07:31:48:1551] N: __lws_lc_tag:  ++ [wsi|1|listen|default||7681] (2)
[2024/10/31 07:31:48:1551] N:  Listening on port: 7681
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
