### PR TITLE
Support setting kubeconfig secret data name

### DIFF
--- a/pkg/controllers/cloudshell_controller.go
+++ b/pkg/controllers/cloudshell_controller.go
@@ -361,7 +361,11 @@ func (c *Controller) StartupWorkerFor(ctx context.Context, cloudshell *cloudshel
 			return err
 		}
 
-		kubeConfigByte = secret.Data["config"]
+		configDataName := os.Getenv("KUBECONFIG_SECRET_DATA_NAME")
+		if configDataName == "" {
+			configDataName = "config"
+		}
+		kubeConfigByte = secret.Data[configDataName]
 	}
 
 	return c.StartupWorker(ctx, cloudshell, kubeConfigByte)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

支持配置 kubeconfig 的 secret data name。当前有些 k8s 集群管理平台已经自动生成了固定格式的 secret（例如 CAPI 使用的是 value 这个 name 存储的 kubeconfig）。如果要适配 config 这个 name 就要重复存储一份 secret。

BTW，是否可以 configDataName 配置在：
```go
// LocalSecretReference is a reference to a secret within the enclosing
// namespace.
type LocalSecretReference struct {
	// Name is the name of resource being referenced.
	Name     string `json:"name,omitempty"`
	DataName string `json:"name,omitempty"` // 例如 CAPI 可以配置为 "value"
}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```
