### PR TITLE
Disable kubeconfig insecure warning

### DIFF
--- a/docker/cloudshell/script/startup.sh
+++ b/docker/cloudshell/script/startup.sh
@@ -20,6 +20,7 @@ fi
 ## Generate config to the path `/root/.kube/config`.
 if [[ -n "${KUBECONFIG}"  ]]; then
   echo "${KUBECONFIG}" > /root/.kube/config
+  chmod 600 /root/.kube/config # By default, it will warn: `Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config`
 fi
 
 echo "export POD_NAMESPACE='${POD_NAMESPACE}'" > /root/.env


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`helm list` will have insecure warning.

![image](https://github.com/user-attachments/assets/d1a87324-00d9-4dc6-9cac-14830004945c)


```
