### PR TITLE
feat: Support setting font size

### DIFF
--- a/docker/cloudshell/script/startup.sh
+++ b/docker/cloudshell/script/startup.sh
@@ -14,6 +14,7 @@ CONTAINER=${7:-}
 PS1=${8:-}
 SERVER_BUFFER_SIZE=${9:-}
 PING_INTERVAL=${10:-}
+FONT_SIZE=${11:-}
 
 if [ -d /root -a "`ls /root`" != "" ]; then         
   rm -rf /root/*                                    
@@ -45,6 +46,7 @@ index=""
 urlarg=""
 server_buffer_size=""
 ping_interval=""
+font_size=""
 
 if [[ "${ONCE}" == "true" ]];then
   once=" --once "
@@ -66,5 +68,9 @@ if [[ -n "${PING_INTERVAL}" ]]; then
   ping_interval=" --ping-interval ${PING_INTERVAL} "
 fi
 
-nohup ttyd -W ${index} ${once} ${urlarg} ${server_buffer_size} ${ping_interval} sh -c "${COMMAND}" > /usr/lib/ttyd/nohup.log 2>&1 &
+if [[ -n "${FONT_SIZE}" ]]; then
+  font_size=" -t fontSize=${FONT_SIZE} "
+fi
+
+nohup ttyd -W ${index} ${once} ${urlarg} ${server_buffer_size} ${ping_interval} ${font_size} sh -c "${COMMAND}" > /usr/lib/ttyd/nohup.log 2>&1 &
 echo "Start ttyd successully."


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support setting font size.

**Configuration sample**
```yaml
apiVersion: cloudshell.cloudtty.io/v1alpha1
kind: CloudShell
metadata:
  name: mycloudshell
  namespace: cloudtty-system
spec:
  cleanup: true
  commandAction: kubectl exec -it mypod -n default -c c1 -- sh -c "bash||sh"
  exposureMode: Ingress
  secretRef:
    name: cloudshell-kubeconfig
  ttlSecondsAfterStarted: 3600
  env:
  - name: TTYD_FONT_SIZE
    value: "26"
  ingressConfig: 
    ingressName: mycloudshell
    namespace: cloudtty-system
    ingressClassName: nginx
```
As shown in the above configuration, you only need to configure the TTYD_FONT_SIZE in cloudshell.env. If not configured, the default font size of the front-end of ttyd is 13. It is recommended to configure a value greater than 13.
