### PR TITLE
fix reset.sh script exit 123

### DIFF
--- a/docker/cloudshell/script/reset.sh
+++ b/docker/cloudshell/script/reset.sh
@@ -20,4 +20,4 @@ if [[ -f /root/.bash_history ]]; then
   rm  /root/.bash_history -f
 fi
 
-ps aux | grep 'ttyd -W' | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1
+ps aux | grep 'ttyd -W' | grep -v 'grep' | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix the ` exit code 123` when resetting work.

**Which issue(s) this PR fixes**:
Fixes #
```shell
E0312 05:38:08.064550       1 cloudshell_controller.go:993] "Failed to run command" err="command terminated with exit code 123" cloudshell="cluster-1741757837137" command=["/usr/lib/ttyd/reset.sh"]
E0312 05:38:08.064590       1 cloudshell_controller.go:762] "Failed to reset worker" err="command terminated with exit code 123" cloudshell="cluster-1741757837137"
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
