### PR TITLE
Fix cloudshell pod error when executing nslookup kubernetes.default

### DIFF
--- a/docker/cloudshell/Dockerfile
+++ b/docker/cloudshell/Dockerfile
@@ -14,9 +14,9 @@ SHELL [ "/bin/bash", "-c" ]
 
 ARG TTYD_VERSION=1.7.8
 
-RUN echo "https://mirrors.aliyun.com/alpine/v3.18/main/" >> /etc/apk/repositories \
+RUN echo "https://mirrors.aliyun.com/alpine/v3.20/main/" >> /etc/apk/repositories \
     && apk update \
-    && apk add wget gcc g++ make \
+    && apk add wget gcc g++ make bind-tools \
     && apk upgrade libexpat \
     && wget https://ohse.de/uwe/releases/lrzsz-0.12.20.tar.gz \
     && tar -xf lrzsz-0.12.20.tar.gz \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fix cloudshell pod error when executing nslookup kubernetes.default

![image](https://github.com/user-attachments/assets/4023c94e-a400-4c19-a788-63b3c6517133)

![image](https://github.com/user-attachments/assets/d775df9c-38a9-481c-ac06-336e9599bff8)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
