### PR TITLE
remove chart installation test for pull request

### DIFF
--- a/.github/workflows/chart-install-test.yaml
+++ b/.github/workflows/chart-install-test.yaml
@@ -1,16 +1,20 @@
 # validate any chart changes under charts directory
-name: Chart Lint
+name: Chart Installation Test
 
 env:
   HELM_VERSION: v3.12.1
+  KIND_VERSION: v0.14.0
+  KIND_NODE_IMAGE: kindest/node:v1.23.4
+  K8S_VERSION: v1.23.4
   DEFAULT_BRANCH: main
 
 on:
-  pull_request:
-    paths:
-      - "charts/cloudtty/**"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
-  chart-lint-test:
+  chart-install-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,3 +56,15 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --debug --target-branch=${{ env.DEFAULT_BRANCH }} --check-version-increment=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.8.0
+        if: steps.list-changed.outputs.changed == 'true'
+        with:
+          wait: 120s
+          # version: ${{ env.KIND_VERSION }}
+          # node_image: ${{ env.KIND_NODE_IMAGE }}
+          # kubectl_version: ${{ env.K8S_VERSION }}
+
+      - name: Run chart-testing (install)
+        run: ct install --debug --target-branch ${{ env.DEFAULT_BRANCH }} --helm-extra-args "--timeout 400s" --helm-extra-set-args "--set=image.tag=latest"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Remove chart installation test for chart-lint-test in call-lint-chart.yaml.

Add `chart-installation-test.yaml` for installation testing after pull request merged.


1. `call-lint-chart.yaml`: For PR validation
   - Triggers on pull requests
   - Performs chart syntax validation only
   - No installation testing
   - Quick feedback for PR issues

2. `chart-installation-test.yaml`: For installation testing
   - Triggers after merging to main branch
   - Performs complete installation testing
   - Validates with kind cluster
   - Ensures chart can be deployed properly

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Remove chart installation test for chart-lint-test.
```
