### PR TITLE
feat: add Go pprof profiling support to cloudshell-controller-manager

### DIFF
--- a/charts/cloudtty/templates/cloushell-manager-deployment.yaml
+++ b/charts/cloudtty/templates/cloushell-manager-deployment.yaml
@@ -55,6 +55,16 @@ spec:
           {{- with (include "cloudtty.operator.featureGates" .) }}
           - {{ . }}
           {{- end }}
+          {{- if .Values.pprof.enabled }}
+          - --enable-pprof
+          - --profiling-bind-address={{ .Values.pprof.bindAddress }}
+          {{- end }}
+          {{- if .Values.pprof.enabled }}
+          ports:
+          - name: pprof
+            containerPort: {{ .Values.pprof.port }}
+            protocol: TCP
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}

--- a/charts/cloudtty/values.yaml
+++ b/charts/cloudtty/values.yaml
@@ -85,6 +85,14 @@ livenessProbe:
 readinessProbe:
   enabled: false
 
+## @param pprof.enabled Enable the Go pprof profiling HTTP server on the controller manager
+## @param pprof.bindAddress Address (host:port) the pprof server binds to
+## @param pprof.port Container port to expose for pprof
+pprof:
+  enabled: false
+  bindAddress: ":6060"
+  port: 6060
+
 
 cloudshell:
   ## @param image.registry cloudshell image registry

--- a/cmd/app/cloudshell-manager.go
+++ b/cmd/app/cloudshell-manager.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/http"
+	nhpprof "net/http/pprof"
 	"os"
 
 	"github.com/cloudtty/cloudtty/pkg/constants"
@@ -92,6 +94,13 @@ func Run(ctx context.Context, config *config.Config) error {
 	klog.Infof("cloudshell-controller-manager version: %s", version.Get())
 	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
+	// Start the pprof server before leader election so it stays reachable even
+	// when this instance is not (or fails to become) the leader, which is exactly
+	// the situation we want to be able to profile.
+	if config.EnablePprof {
+		go serveProfiling(ctx, config.ProfilingBindAddress)
+	}
+
 	if !config.LeaderElection.LeaderElect {
 		return StartControllers(config, ctx.Done())
 	}
@@ -167,4 +176,28 @@ func StartControllers(c *config.Config, stopCh <-chan struct{}) error {
 
 	<-stopCh
 	return nil
+}
+
+// serveProfiling runs an HTTP server exposing the net/http/pprof debugging
+// endpoints. It registers the handlers on a dedicated mux (rather than the
+// global DefaultServeMux) so pprof is only ever reachable through this server.
+// The server is shut down when ctx is cancelled.
+func serveProfiling(ctx context.Context, addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", nhpprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", nhpprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", nhpprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", nhpprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", nhpprof.Trace)
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close()
+	}()
+
+	klog.Infof("Starting pprof server on %s", addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		klog.Errorf("pprof server error: %v", err)
+	}
 }

--- a/cmd/app/config/config.go
+++ b/cmd/app/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	NodeSelector     map[string]string
 	Resources        *cloudshellv1alpha1.ResourceSetting
 
+	EnablePprof          bool
+	ProfilingBindAddress string
+
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
 }
 

--- a/cmd/app/options/option.go
+++ b/cmd/app/options/option.go
@@ -59,6 +59,11 @@ type Options struct {
 	NodeSelector    map[string]string
 	Resources       cloudshellv1alpha1.ResourceSetting
 	Logs            *logs.Options
+
+	// EnablePprof enables the pprof profiling HTTP server for debugging.
+	EnablePprof bool
+	// ProfilingBindAddress is the TCP address the pprof server binds to.
+	ProfilingBindAddress string
 }
 
 func NewOptions() (*Options, error) {
@@ -102,6 +107,10 @@ func (o *Options) Flags() cliflag.NamedFlagSets {
 	genericfs.StringVar(&o.ClouShellImage, "cloudshell-image", "", "The cloudshell image.")
 	genericfs.StringToStringVar(&o.NodeSelector, "cloudshell-node-selector", o.NodeSelector, "The cloudshell node selector.")
 	genericfs.Var(&o.Resources, "cloudshell-resources", "The cloudshell resources.")
+
+	pproffs := nfs.FlagSet("pprof")
+	pproffs.BoolVar(&o.EnablePprof, "enable-pprof", false, "Enable the pprof profiling HTTP server for debugging.")
+	pproffs.StringVar(&o.ProfilingBindAddress, "profiling-bind-address", ":6060", "The TCP address that the pprof server binds to (host:port). Only used when --enable-pprof is set.")
 
 	fs := nfs.FlagSet("misc")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
@@ -167,6 +176,9 @@ func (o *Options) Config() (*config.Config, error) {
 		CloudShellImage:  o.ClouShellImage,
 		NodeSelector:     o.NodeSelector,
 		Resources:        &o.Resources,
+
+		EnablePprof:          o.EnablePprof,
+		ProfilingBindAddress: o.ProfilingBindAddress,
 
 		LeaderElection: o.LeaderElection,
 	}, nil

--- a/cmd/app/options/validate.go
+++ b/cmd/app/options/validate.go
@@ -16,6 +16,8 @@ limitations under the License.
 package options
 
 import (
+	"net"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -30,6 +32,12 @@ func (o *Options) Validate() field.ErrorList {
 
 	if o.MaxWorkerLimit < 0 {
 		errs = append(errs, field.Invalid(newPath.Child("MaxWorkerLimit"), o.MaxWorkerLimit, "max-worker-limit must be greater than or equals 0"))
+	}
+
+	if o.EnablePprof {
+		if _, _, err := net.SplitHostPort(o.ProfilingBindAddress); err != nil {
+			errs = append(errs, field.Invalid(newPath.Child("ProfilingBindAddress"), o.ProfilingBindAddress, "profiling-bind-address must be a valid host:port when --enable-pprof is set"))
+		}
 	}
 
 	return errs


### PR DESCRIPTION
## What

Adds an optional Go pprof profiling HTTP server to `cloudshell-controller-manager`.

- New flags: `--enable-pprof` (default `false`) and `--profiling-bind-address` (default `:6060`).
- The pprof server starts **before leader election**, so it is reachable even when this instance is not (or fails to become) the leader.
- Handlers are registered on a dedicated `http.ServeMux` (not the global `DefaultServeMux`) and the server shuts down on context cancel.
- Bind address is validated as `host:port` when pprof is enabled.
- Helm chart: new `pprof.enabled` / `pprof.bindAddress` / `pprof.port` values that wire the container args and a `pprof` `containerPort`.

## Why

We hit a case where, on a cluster with slow etcd disks, the controller intermittently timed out acquiring its leader-election lease and became stuck, no longer reconciling `CloudShell` CRDs. The controller manager exposed **no pprof endpoint**, so there was no way to capture a goroutine dump and see where it was blocked. This change provides that observability so the stuck path can be diagnosed (e.g. `go tool pprof http://<pod>:6060/debug/pprof/goroutine`).

Starting pprof before leader election is deliberate: a wedged / non-leader instance is exactly what we need to profile.

## Scope / notes

- This PR is **observability only**. Fixing the underlying lease-timeout retry behavior and adding health/liveness probes for auto-restart are intentionally left as follow-ups.
- The chart already references `livenessProbe`/`readinessProbe`, but there is still no health endpoint backing them — that is a separate change.
- `cloudshell-controller-manager` does not use controller-runtime's `Manager`, and the vendored `controller-runtime v0.14.6` predates `manager.Options.PprofBindAddress`, so pprof is wired manually rather than via the manager.

## Verification

- `go build ./...` and `go vet ./cmd/...` are clean.
- `go run ./cmd --help` shows both flags.
- `helm template charts/cloudtty --set pprof.enabled=true` emits the args + `pprof` containerPort; the default render emits neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)